### PR TITLE
Add support of interface-variable to Assigned function

### DIFF
--- a/Source/uPSCompiler.pas
+++ b/Source/uPSCompiler.pas
@@ -8087,7 +8087,9 @@ function TPSPascalCompiler.ProcessSub(BlockInfo: TPSBlockInfo): Boolean;
                 result := nil;
                 exit;
               end;
-              if (GetTypeNo(BlockInfo, NewVar) = nil) or ((GetTypeNo(BlockInfo, NewVar).BaseType <> btClass) and
+              if (GetTypeNo(BlockInfo, NewVar) = nil) or 
+                ((GetTypeNo(BlockInfo, NewVar).BaseType <> btClass) and
+                (GetTypeNo(BlockInfo, NewVar).BaseType <> btInterface) and
                 (GetTypeNo(BlockInfo, NewVar).BaseType <> btPChar) and
                 (GetTypeNo(BlockInfo, NewVar).BaseType <> btString)) then
               begin


### PR DESCRIPTION
Assign function was compatible with classe, PChar and string but not compatible with interface.
