### PR TITLE
Yet another x64 bug fix

### DIFF
--- a/Source/x64.inc
+++ b/Source/x64.inc
@@ -666,7 +666,7 @@ begin
         btu32,bts32:   tbtu32(res.dta^) := _RAX;
         btPChar:       pansichar(res.dta^) := Pansichar(_RAX);
         bts64: tbts64(res.dta^) := Int64(_RAX);
-        btCurrency:    tbtCurrency(res.Dta^) := Int64(_RAX);
+        btCurrency:    tbts64(res.Dta^) := Int64(_RAX);
         btInterface,
         btVariant,
         {$IFDEF x64_string_result_as_varparameter}


### PR DESCRIPTION
Currency type is internally an int64. Casting its binary representation in RAX to an an int64 and affecting it to a currency will result in a *10000 multiplication.
