### PR TITLE
Compiler bug in const arrays

### DIFF
--- a/Source/uPSCompiler.pas
+++ b/Source/uPSCompiler.pas
@@ -6152,9 +6152,9 @@ function TPSPascalCompiler.ProcessSub(BlockInfo: TPSBlockInfo): Boolean;
         exit;
       end;
       if TPSType(FarrType).BaseType = btVariant then
-        FArrType := FindAndAddType(self, '', 'array of variant');
+        FArrType := at2ut(FindAndAddType(self, '!OPENARRAYOFVARIANT', 'array of variant'));
       if TPSType(FarrType).BaseType <> btArray then 
-        FArrType := FindAndAddType(self, '', 'array of variant');
+        FArrType := at2ut(FindAndAddType(self, '!OPENARRAYOFVARIANT', 'array of variant'));
 
       tmpp := AllocStackReg(FArrType);
       tmpc := AllocStackReg(FindBaseType(bts32));


### PR DESCRIPTION
There a compiler bug in array constants. A construct like

procedure B(eType : TObject);
begin
    if eType is TObject then ;
end;

function A(eVal : int32) : booleen;
begin
    result:=not(eVal in [1,2]);
end;         

begin
    A(1);
    A(2);
    A(3);
end;

Cause an AV in UpsCompiler line 6185. The root cause is the use of FindAndAddType with no name. The function return the last created anonymous type. In the previous sample it's a Type created by the "is" operator which is not an array. Casting it to TPSArrayType lead to the AV.
