### PR TITLE
Fix memory leak TPSExec.InnerfuseCall in fpc

### DIFF
--- a/Source/x86.inc
+++ b/Source/x86.inc
@@ -543,6 +543,7 @@ begin
             if not GetPtr(rp(Params[0])) then exit; // this goes first
             RegUsage := 2;
             EDX := Longint(_Self);
+            DisposePPSVariantIFC(Params[0]);
             Params.Delete(0);
           end else
 {$ENDIF}


### PR DESCRIPTION
This fix the memory leak reported in [issue 61](https://github.com/remobjects/pascalscript/issues/61)
