### PR TITLE
Fix defines for FPC 3.0

### DIFF
--- a/Source/PascalScriptFPC.inc
+++ b/Source/PascalScriptFPC.inc
@@ -4,15 +4,14 @@
   {$ifndef mswindows}
     {$DEFINE PS_NOIDISPATCH}
   {$endif}  
-  {.$if (fpc_version=2) and (fpc_release>=3) and (fpc_patch>=1)}
-  {$if (fpc_version=2) and ((fpc_release=2) and (fpc_patch>=4)) or (fpc_release>2)}
+  {$if (fpc_version>2) or ((fpc_version=2) and ((fpc_release=2) and (fpc_patch>=4)) or (fpc_release>2))}
     {$UNDEF FPC_OLD_FIX}
     {$DEFINE PS_STACKALIGN}
     {$UNDEF PS_FPCSTRINGWORKAROUND}
     {$DEFINE PS_RESBEFOREPARAMETERS}
     {$DEFINE x64_string_result_as_varparameter}    
     {$ifdef mswindows}
-      {$if (fpc_version=2) and (fpc_release>5)}
+      {$if (fpc_version>2) or ((fpc_version=2) and (fpc_release>5))}
        {$DEFINE PS_FPC_HAS_COM}
       {$endif}
     {$endif}


### PR DESCRIPTION
This change fix the version test in PascalScriptFPC.inc to have the correct defines for FPC 3.0