### PR TITLE
Runtime optimization + x64 bug fix

### DIFF
--- a/Source/x64.inc
+++ b/Source/x64.inc
@@ -3,7 +3,7 @@
   {$DEFINE x64_string_result_as_varparameter}
 {$ENDIF}
 
-{ implementaStotion of x64 abi }
+{ implementation of x64 abi }
 //procedure DebugBreak; external 'Kernel32.dll';
 const
   EmptyPchar: array[0..0] of char = #0;

--- a/Source/x64.inc
+++ b/Source/x64.inc
@@ -3,7 +3,7 @@
   {$DEFINE x64_string_result_as_varparameter}
 {$ENDIF}
 
-{ implementation of x64 abi }
+{ implementaStotion of x64 abi }
 //procedure DebugBreak; external 'Kernel32.dll';
 const
   EmptyPchar: array[0..0] of char = #0;
@@ -391,19 +391,6 @@ _XMM0: Double;
   end;
 {$ENDIF}
 
-  procedure StoreStack(const aData; Len: Integer);
-  var
-    p: Pointer;
-  begin
-    if Len > 8 then
-      if Length(Stack) mod 16 <> 0 then begin
-        SetLength(Stack, Length(Stack)+ (16-(Length(Stack) mod 16)));
-      end;
-    SetLength(Stack, Length(Stack)+Len);
-    p := @Stack[Length(Stack)-Len];
-    Move(aData, p^, Len);
-  end;
-
 {$IFDEF WINDOWS}
   procedure StoreReg(data: Double); overload;
   var p: Pointer;
@@ -476,6 +463,11 @@ _XMM0: Double;
   end;
   {$ENDIF}
   function GetPtr(fVar: PPSVariantIFC): Boolean;
+  type
+    TMethodCallData = record
+        AType : Byte;
+        Data : TMethod;
+    end;
   var
     varPtr: Pointer;
     //UseReg: Boolean;
@@ -493,6 +485,8 @@ _XMM0: Double;
             begin
               p := CreateOpenArray(True, Self, FVar);
               if p = nil then exit;
+              if CallData = nil then
+                CallData := TPSList.Create;
               CallData.Add(p);
               StoreReg(IPointer(POpenArray(p)^.Data));
               StoreReg(IPointer(POpenArray(p)^.ItemCount -1));
@@ -541,6 +535,8 @@ _XMM0: Double;
             begin
               p := CreateOpenArray(False, SElf, FVar);
               if p =nil then exit;
+              if CallData = nil then
+                CallData := TPSList.Create;
               CallData.Add(p);
               StoreReg(IPointer(POpenArray(p)^.Data));
               StoreReg(IPointer(POpenArray(p)^.ItemCount -1));
@@ -608,10 +604,16 @@ _XMM0: Double;
 
         btProcPtr:
           begin
-            GetMem(p, PointerSize2);
-            TMethod(p^) := MKMethod(Self, Longint(FVar.Dta^));
-            StoreStack(p^, Pointersize2);
-            FreeMem(p);
+            GetMem(p, sizeof(TMethodCallData));
+            TMethodCallData(p^).AType:=255;
+            TMethodCallData(p^).Data.Code:=nil;
+            TMethodCallData(p^).Data.Data:=nil;
+            if CallData = nil then
+              CallData := TPSList.Create;
+            CallData.Add(p);
+// Uncomment when Handler will be implemented
+//            TMethodCallData(p^).Data := MKMethod(Self, Longint(FVar.Dta^));
+            StoreReg(IPointer(@TMethodCallData(p^).Data));
           end;
 
         bts64:
@@ -627,7 +629,7 @@ begin
   if Address = nil then
     exit; // need address
   SetLength(Stack, 0);
-  CallData := TPSList.Create;
+  CallData := nil;
   res := rp(res);
   if res <> nil then
     res.VarParam := true;
@@ -749,14 +751,17 @@ begin
     end;
     Result := True;
   finally
-    for i := CallData.Count -1 downto 0 do
+    if CallData<>nil then
     begin
-      pp := CallData[i];
-      case pp^ of
-        0: DestroyOpenArray(Self, Pointer(pp));
+      for i := CallData.Count -1 downto 0 do
+      begin
+        pp := CallData[i];
+        case pp^ of
+          0: DestroyOpenArray(Self, Pointer(pp));
+        end;
       end;
+      CallData.Free;
     end;
-    CallData.Free;
   end;
 end;
 

--- a/Source/x64.inc
+++ b/Source/x64.inc
@@ -758,6 +758,7 @@ begin
         pp := CallData[i];
         case pp^ of
           0: DestroyOpenArray(Self, Pointer(pp));
+          255: FreeMem(Pointer(pp));
         end;
       end;
       CallData.Free;

--- a/Source/x86.inc
+++ b/Source/x86.inc
@@ -291,6 +291,8 @@ var
             begin
               p := CreateOpenArray(True, Self, FVar);
               if p = nil then exit;
+              if CallData = nil then
+                CallData := TPSList.Create();
               CallData.Add(p);
               case RegUsage of
                 0: begin EAX := Longint(POpenArray(p)^.Data); Inc(RegUsage); end;
@@ -365,6 +367,8 @@ var
             begin
               p := CreateOpenArray(False, SElf, FVar);
               if p =nil then exit;
+              if CallData = nil then
+                CallData := TPSList.Create();
               CallData.Add(p);
               case RegUsage of
                 0: begin EAX := Longint(POpenArray(p)^.Data); Inc(RegUsage); end;
@@ -526,7 +530,7 @@ begin
   if Address = nil then
     exit; // need address
   Stack := '';
-  CallData := TPSList.Create;
+  CallData := nil;
   res := rp(res);
   if res <> nil then
     res.VarParam := true;
@@ -771,14 +775,17 @@ begin
         end;
     end;
   finally
-    for i := CallData.Count -1 downto 0 do
+    if CallData<>nil then
     begin
-      pp := CallData[i];
-      case pp^ of
-        0: DestroyOpenArray(Self, Pointer(pp));
+      for i := CallData.Count -1 downto 0 do
+      begin
+        pp := CallData[i];
+        case pp^ of
+          0: DestroyOpenArray(Self, Pointer(pp));
+        end;
       end;
+      CallData.Free;
     end;
-    CallData.Free;
   end;
 end;
 


### PR DESCRIPTION
Two changes :
* Passing of procptr parameters is broken on x64 (at least for delphi / windows). Technicaly it is a record and a record must be passed by ref not on the stack. Current code lead to AV. I don't know how free pascal handle this.
Calling of proc parameter is not supported on x64 right now because of missing implementation, but this proposed change at least prevent a crash.
* Optimization to create the CallData List only if needed. It's only used for some array (and now for procptr params)