### PR TITLE
Allow TPSPascalCompiler.AddClass to adjust InheritsFrom

### DIFF
--- a/Source/uPSCompiler.pas
+++ b/Source/uPSCompiler.pas
@@ -13580,6 +13580,12 @@ begin
   Result := FindClass(tbtstring(aClass.ClassName));
   if (Result<>nil) and not(FAllowDuplicateRegister) then
     Raise EPSCompilerException.CreateFmt(RPS_DuplicateIdent, [aClass.ClassName]);
+  if Result <> nil then
+  begin
+    if InheritsFrom <> nil then
+      Result.FInheritsFrom := InheritsFrom;
+    exit;
+  end;
   f := AddType(tbtstring(aClass.ClassName), btClass);
   Result := TPSCompileTimeClass.CreateC(aClass, Self, f);
   Result.FInheritsFrom := InheritsFrom;


### PR DESCRIPTION
Allow TPSPascalCompiler.AddClass re-registration of a class (if AllowDuplicateRegister) to adjust InheritsFrom instead of adding duplicate class registration

I hope I don't create problems...this is my first experience with GitHub :smile_cat: 

I'll follow what I understood of the rules : create 1 independent Pull Request for each of my proposed modifications