### PR TITLE
replace movd to movq for move data into xmmX registers (lazarus 64bit linux)

### DIFF
--- a/Source/x64.inc
+++ b/Source/x64.inc
@@ -222,7 +222,7 @@ asm
   cvtsd2ss xmm0,[rdx]
   jmp @skipxmm0re
   @skipxmm0:
-  movd xmm0,[rdx]
+  movq xmm0,[rdx]            // move quadword to xmm0 from _XMM0
   @skipxmm0re:
 
   // xmm1
@@ -231,7 +231,7 @@ asm
   cvtsd2ss xmm1,[rax+48]
   jmp @skipxmm1re
   @skipxmm1:
-  movd xmm1,[rax+48]
+  movq xmm1,[rax+48]         // move quadword to xmm1 from Registers._XMM1
   @skipxmm1re:
 
   // xmm2
@@ -240,7 +240,7 @@ asm
   cvtsd2ss xmm2,[rax+56]
   jmp @skipxmm2re
   @skipxmm2:
-  movd xmm2,[rax+56]
+  movq xmm2,[rax+56]         // move quadword to xmm2 from Registers._XMM2
   @skipxmm2re:
 
   // xmm3
@@ -249,7 +249,7 @@ asm
   cvtsd2ss xmm3,[rax+64]
   jmp @skipxmm3re
   @skipxmm3:
-  movd xmm3,[rax+64]
+  movq xmm3,[rax+64]         // move quadword to xmm3 from Registers._XMM3
   @skipxmm3re:
 
   // xmm4
@@ -258,7 +258,7 @@ asm
   cvtsd2ss xmm4,[rax+72]
   jmp @skipxmm4re
   @skipxmm4:
-  movd xmm4,[rax+72]
+  movq xmm4,[rax+72]         // move quadword to xmm4 from Registers._XMM4
   @skipxmm4re:
 
   // xmm5
@@ -267,7 +267,7 @@ asm
   cvtsd2ss xmm5,[rax+80]
   jmp @skipxmm5re
   @skipxmm5:
-  movd xmm5,[rax+80]
+  movq xmm5,[rax+80]         // move quadword to xmm5 from Registers._XMM5
   @skipxmm5re:
 
   // xmm6
@@ -276,15 +276,16 @@ asm
   cvtsd2ss xmm6,[rax+88]
   jmp @skipxmm6re
   @skipxmm6:
-  movd xmm6,[rax+88]
+  movq xmm6,[rax+88]         // move quadword to xmm6 from Registers._XMM6
   @skipxmm6re:
+
 // xmm7
   bt [rax+104], 7
   jnc @skipxmm7
   cvtsd2ss xmm7,[rax+96]
   jmp @skipxmm7re
   @skipxmm7:
-  movd xmm7,[rax+96]
+  movq xmm7,[rax+96]         // move quadword to xmm7 from Registers._XMM7
   @skipxmm7re:
 
 


### PR DESCRIPTION
In my opinion it is BUG use movd  for move 64bit data , now works for me 
function with duble parameters 