### PR TITLE
Fixed function VarType not exported in runtine in FPC

### DIFF
--- a/Source/uPSRuntime.pas
+++ b/Source/uPSRuntime.pas
@@ -9389,9 +9389,7 @@ begin
   {$ENDIF}
   RegisterDelphiFunction(@Null, 'NULL', cdRegister);
   RegisterDelphiFunction(@VarIsNull, 'VARISNULL', cdRegister);
-  {$IFNDEF FPC}
   RegisterDelphiFunction(@VarType, 'VARTYPE', cdRegister);
-  {$ENDIF}
   {$IFNDEF PS_NOIDISPATCH}
   RegisterDelphiFunction(@IDispatchInvoke, 'IDISPATCHINVOKE', cdregister);
   {$ENDIF}


### PR DESCRIPTION
Dunno what somebody had in mind. This function is in both FPC 2.6 and 3.0.
It's also not in IFDEFS in uPSCompiler