### PR TITLE
Fix for #153: Event registered with RegisterEventPropertyHelper fail in Win64 runtime

### DIFF
--- a/Source/InvokeCall.inc
+++ b/Source/InvokeCall.inc
@@ -57,7 +57,8 @@ begin
         btU32, btS32:                      Arg := TValue.From(pCardinal(fvar.dta)^);
         {$IFNDEF PS_NOINT64}bts64:{$ENDIF} Arg := TValue.From(pint64(fvar.dta)^);
         btSingle:                          Arg := TValue.From(PSingle(fvar.dta)^);
-        btDouble, btExtended:              Arg := TValue.From(PDouble(fvar.dta)^);
+        btDouble:                          Arg := TValue.From(PDouble(fvar.dta)^);
+        btExtended:                        Arg := TValue.From(PExtended(fvar.dta)^);
         btPChar:                           Arg := TValue.From(ppchar(fvar.dta)^);
         btChar:                            Arg := TValue.From(pchar(fvar.dta)^);
         btClass:                           Arg := TValue.From(TObject(fvar.dta^));
@@ -113,7 +114,8 @@ begin
       btU32, btS32:            pCardinal(res.dta)^ := Cardinal(Invoke(Address,Args,SysCalConv,TypeInfo(Cardinal),False,IsConstr).AsInteger);
       {$IFNDEF PS_NOINT64}bts64:{$ENDIF}   pInt64(res.dta)^ := Int64(Invoke(Address,Args,SysCalConv,TypeInfo(Int64),False,IsConstr).AsInt64);
       btSingle:                psingle(res.dta)^ := Double(Invoke(Address,Args,SysCalConv,TypeInfo(Single),False,IsConstr).AsExtended);
-      btDouble, btExtended:    pdouble(res.dta)^ := Double(Invoke(Address,Args,SysCalConv,TypeInfo(Double),False,IsConstr).AsExtended);
+      btDouble:                pdouble(res.dta)^ := Double(Invoke(Address,Args,SysCalConv,TypeInfo(Double),False,IsConstr).AsExtended);
+      btExtended:              pextended(res.dta)^ := Extended(Invoke(Address,Args,SysCalConv,TypeInfo(Extended),False,IsConstr).AsExtended);
       btPChar:                 ppchar(res.dta)^ := pchar(Invoke(Address,Args,SysCalConv,TypeInfo(PChar),False,IsConstr).AsType<PChar>());
       btChar:                  pchar(res.dta)^ := Char(Invoke(Address,Args,SysCalConv,TypeInfo(Char),False,IsConstr).AsType<Char>());
       btSet:


### PR DESCRIPTION
This is a temporary fix.  It shall be reviewed by PascalScript expert to further fix the issue.  The reason that the issue happen is due to a code in x64.inc:

```
        btProcPtr:
          begin
            GetMem(p, PointerSize2);
            TMethod(p^) := MKMethod(Self, Longint(FVar.Dta^));
            StoreStack(p^, Pointersize2);
            FreeMem(p);
          end;
```

It didn't invoke StoreReg to inject a value to Registers._RDX.  As a result, it fail at call RAX in later stage.  The fix attempt to make it fit for the issue.  However, it need to review further to make it better.
