### PR TITLE
Add support for 'array of _Enum_Type_'  types for registered methods.

### DIFF
--- a/Source/uPSC_forms.pas
+++ b/Source/uPSC_forms.pas
@@ -171,7 +171,11 @@ begin
 {$IFDEF PS_PANSICHAR}
     RegisterMethod('function MessageBox(Text,Caption: PAnsiChar; Flags: Word): Integer');
 {$ELSE}
+{$IFDEF UNICODE}
+    RegisterMethod('function MessageBox(Text,Caption: string; Flags: Word): Integer');
+  {$ELSE}
     RegisterMethod('function MessageBox(Text,Caption: PChar; Flags: Word): Integer');
+  {$ENDIF}
 {$ENDIF}
     RegisterMethod('procedure Minimize');
     RegisterMethod('procedure ProcessMessages');

--- a/Source/uPSCompiler.pas
+++ b/Source/uPSCompiler.pas
@@ -2144,6 +2144,7 @@ begin
             {$ENDIF}
               btClass: VCType := FindAndAddType(Owner, '!OPENARRAYOFTOBJECT', 'array of TObject');
               btRecord: VCType := FindAndAddType(Owner, '!OPENARRAYOFRECORD_'+FastUpperCase(Parser.OriginalToken), 'array of ' +FastUpperCase(Parser.OriginalToken));
+              btEnum: VCType := FindAndAddType(Owner, '!OPENARRAYOFENUM_' + FastUpperCase(Parser.OriginalToken), 'array of ' + FastUpperCase(Parser.OriginalToken));
             else
               begin
                 if Parser <> CustomParser then


### PR DESCRIPTION
PS does not support method register with parameter of type 

`array of TMyType`

where TMyType is an enumeration.

Also its not possible to use type

`array of Boolean`

because Boolean is considered as enum type in pascal script.
This will also add support for 'array of Boolean' type, as Boolean considered as enum in pascal script.