### PR TITLE
Fix for #180 (https://github.com/remobjects/pascalscript/issues/180)

### DIFF
--- a/Source/uPSRuntime.pas
+++ b/Source/uPSRuntime.pas
@@ -9320,7 +9320,7 @@ begin
 end;
 
 
-{$IFNDEF DELPHI6UP}
+{$IFDEF DELPHI6UP}
 function _VarArrayGet(var S : Variant; I : Integer) : Variant;
 begin
   result := VarArrayGet(S, [I]);
@@ -9420,7 +9420,7 @@ begin
   RegisterFunctionName('WStrSet', DefProc, Pointer(44), nil);
 
   {$ENDIF}
-  {$IFNDEF DELPHI6UP}
+  {$IFDEF DELPHI6UP}
   RegisterDelphiFunction(@_VarArrayGet, 'VarArrayGet', cdRegister);
   RegisterDelphiFunction(@_VarArraySet, 'VarArraySet', cdRegister);
   {$ENDIF}


### PR DESCRIPTION
- enables VarArrayGet/-Set for Delphi 6 or higher
- since D5 VarArrayGet seems not to be accessible the best solution is to negate $IFNDEF DELPHI6UP into $IFDEF DELPHI6UP