### PR TITLE
1) Delphi methods calling fully rewritten to Invoke calling. Works on…

### DIFF
--- a/Source/InvokeCall.inc
+++ b/Source/InvokeCall.inc
@@ -1,0 +1,182 @@
+function TPSExec.InnerfuseCall(_Self, Address: Pointer; CallingConv: TPSCallingConvention; Params: TPSList; res: PPSVariantIFC): Boolean;
+var SysCalConv : TCallConv;
+    Args: TArray<TValue>;
+    Arg : TValue;
+    i : Integer;
+    fvar: PPSVariantIFC;
+    IsConstr : Boolean;
+    ctx: TRTTIContext;
+    RttiType : TRttiType;
+    ResValue : TValue;
+begin
+  Result := False;
+  case CallingConv of
+    cdRegister : SysCalConv := ccReg;
+    cdPascal : SysCalConv := ccPascal;
+    cdCdecl : SysCalConv := ccCdecl;
+    cdStdCall : SysCalConv := ccStdCall;
+    cdSafeCall : SysCalConv := ccSafeCall;
+  else
+    SysCalConv := ccReg;//to prevent warning "W1036 Variable might not have been initialized"
+  end;
+  
+  if Assigned(_Self) then
+    Args := Args + [TValue.From<Pointer>( _Self )];
+
+  for I := 0 to Params.Count - 1 do
+  begin
+    if Params[i] = nil
+      then Exit;
+    fvar := Params[i];
+
+    if fvar.varparam then
+    begin { var param }
+      case fvar.aType.BaseType of
+        btArray, btVariant, btSet, btStaticArray, btRecord, btInterface, btClass, {$IFNDEF PS_NOWIDESTRING} btWideString, btWideChar, {$ENDIF}
+        btU8, btS8, btU16, btS16, btU32, btS32, btSingle, btDouble, btExtended, btString, btPChar, btChar, btCurrency,
+        btUnicodeString
+        {$IFNDEF PS_NOINT64}, bts64{$ENDIF}:
+          Arg := TValue.From<Pointer>( Pointer(fvar.dta) );  { TODO: test all }
+        else
+          begin
+            Exit;
+          end;
+      end;
+    end
+    else
+    begin  { not a var param }
+      case fvar.aType.BaseType of
+        { add normal params here }
+        {$IFNDEF PS_NOWIDESTRING}btWidestring,btUnicodestring, {$ENDIF}
+        btString:                          Arg := TValue.From(pstring(fvar.dta)^);
+        btU8, btS8:                        Arg := TValue.From(pbyte(fvar.dta)^);
+        btU16, BtS16:                      Arg := TValue.From(pword(fvar.dta)^);
+        btU32, btS32:                      Arg := TValue.From(pCardinal(fvar.dta)^);
+        {$IFNDEF PS_NOINT64}bts64:{$ENDIF} Arg := TValue.From(pint64(fvar.dta)^);
+        btSingle:                          Arg := TValue.From(PSingle(fvar.dta)^);
+        btDouble, btExtended:              Arg := TValue.From(PDouble(fvar.dta)^);
+        btPChar:                           Arg := TValue.From(ppchar(fvar.dta)^);
+        btChar:                            Arg := TValue.From(pchar(fvar.dta)^);
+        btClass:                           Arg := TValue.From(TObject(fvar.dta^));
+        btRecord:                          Arg := TValue.From<Pointer>(fvar.dta); //works
+        btStaticArray:                     Arg := TValue.From<Pointer>(fvar.dta); //works
+        btArray:
+          begin
+             if Copy(fvar.aType.ExportName, 1, 10) = '!OPENARRAY' then
+             begin  //openarray
+               //in case of openarray we should provide TWO params: first is pointer to array,
+               Args := Args + [TValue.From<Pointer>(Pointer(fvar.Dta^))];
+               //2nd - integer with arraylength - 1 (high)
+               Arg := TValue.From<Integer>(PSDynArrayGetLength(Pointer(fvar.Dta^), fvar.aType)-1);// = High of OpenArray
+             end
+             else //dynarray = just send pointer
+               Arg := TValue.From<Pointer>(fvar.dta);
+          end;
+        btSet:
+          begin
+            case TPSTypeRec_Set(fvar.aType).aByteSize  of
+              1: Arg := TValue.From(pbyte(fvar.dta)^);
+              2: Arg := TValue.From(pWord(fvar.dta)^);
+              3,
+              4: Arg := TValue.From(pCardinal(fvar.dta)^);
+              else
+                Arg := TValue.From<Pointer>(fvar.dta);
+            end;
+          end;
+        else
+//            writeln(stderr, 'Parameter type not implemented!');
+          Exit;
+      end;  { case }
+    end;
+    Args := Args + [Arg];
+  end;
+
+  IsConstr := (Integer(CallingConv) and 64) <> 0;
+  if not assigned(res) then
+  begin
+    Invoke(Address,Args,SysCalConv,nil,False,IsConstr);  { ignore return }
+  end
+  else begin
+    case res.atype.basetype of
+      { add result types here }
+      btString:                tbtstring(res.dta^) := Invoke(Address,Args,SysCalConv,TypeInfo(String),False,IsConstr).AsString;
+      {$IFNDEF PS_NOWIDESTRING}
+      btUnicodeString:         tbtunicodestring(res.dta^) := Invoke(Address,Args,SysCalConv,TypeInfo(String),False,IsConstr).AsString;
+      btWideString:            tbtWideString(res.dta^) := Invoke(Address,Args,SysCalConv,TypeInfo(String),False,IsConstr).AsString;
+      {$ENDIF}
+      btU8, btS8:              pbyte(res.dta)^ := Byte(Invoke(Address,Args,SysCalConv,TypeInfo(Byte),False,IsConstr).AsInteger);
+      btU16, btS16:            pword(res.dta)^ := word(Invoke(Address,Args,SysCalConv,TypeInfo(Word),False,IsConstr).AsInteger);
+      btU32, btS32:            pCardinal(res.dta)^ := Cardinal(Invoke(Address,Args,SysCalConv,TypeInfo(Cardinal),False,IsConstr).AsInteger);
+      {$IFNDEF PS_NOINT64}bts64:{$ENDIF}   pInt64(res.dta)^ := Int64(Invoke(Address,Args,SysCalConv,TypeInfo(Int64),False,IsConstr).AsInt64);
+      btSingle:                psingle(res.dta)^ := Double(Invoke(Address,Args,SysCalConv,TypeInfo(Single),False,IsConstr).AsExtended);
+      btDouble, btExtended:    pdouble(res.dta)^ := Double(Invoke(Address,Args,SysCalConv,TypeInfo(Double),False,IsConstr).AsExtended);
+      btPChar:                 ppchar(res.dta)^ := pchar(Invoke(Address,Args,SysCalConv,TypeInfo(PChar),False,IsConstr).AsType<PChar>());
+      btChar:                  pchar(res.dta)^ := Char(Invoke(Address,Args,SysCalConv,TypeInfo(Char),False,IsConstr).AsType<Char>());
+      btSet:
+        begin
+          case TPSTypeRec_Set(res.aType).aByteSize  of
+            1: byte(res.Dta^) := Byte(Invoke(Address,Args,SysCalConv,TypeInfo(Byte),False,IsConstr).AsInteger);
+            2: word(res.Dta^) := word(Invoke(Address,Args,SysCalConv,TypeInfo(Word),False,IsConstr).AsInteger);
+            3,
+            4: Longint(res.Dta^) := Cardinal(Invoke(Address,Args,SysCalConv,TypeInfo(Cardinal),False,IsConstr).AsInteger);
+            else
+            begin
+              for RttiType in ctx.GetTypes do
+                if (RttiType.Name.ToUpper.EndsWith(res.aType.FExportName)) and (RttiType.TypeKind = tkSet)
+                  and (RttiType.TypeSize = TPSTypeRec_Set(res.aType).aByteSize) then
+                begin
+                  Invoke(Address,Args,SysCalConv,RttiType.Handle,False,IsConstr).ExtractRawData(res.dta);
+                  Break;
+                end;
+            end;
+          end;
+        end;
+      btClass:
+      begin
+        for RttiType in ctx.GetTypes do
+          if (RttiType.Name.ToUpper.EndsWith(res.aType.FExportName)) and (RttiType.TypeKind = tkClass) then
+          begin
+            TObject(res.dta^) := Invoke(Address,Args,SysCalConv,RttiType.Handle,False,IsConstr).AsObject;
+            Break;
+          end;
+      end;
+      btStaticArray:
+      begin
+        for RttiType in ctx.GetTypes do
+          if (RttiType.Name.ToUpper.EndsWith(res.aType.FExportName)) and (RttiType.TypeKind = tkArray) then
+          begin
+            CopyArrayContents(res.dta, Invoke(Address,Args,SysCalConv,RttiType.Handle,False,IsConstr).GetReferenceToRawData, TPSTypeRec_StaticArray(res.aType).Size, TPSTypeRec_StaticArray(res.aType).ArrayType);
+            Break;
+          end;
+      end;
+      btRecord:
+      begin
+        for RttiType in ctx.GetTypes do
+          if (RttiType.Name.ToUpper.EndsWith(res.aType.FExportName)) and (RttiType.TypeKind = tkRecord) then
+          begin
+            CopyArrayContents(res.dta, (Invoke(Address,Args,SysCalConv,RttiType.Handle,False,IsConstr).GetReferenceToRawData), 1, res.aType);
+            Break;
+          end;
+      end;
+      btArray: //need to check with open arrays
+      begin
+        for RttiType in ctx.GetTypes do
+          if (RttiType.Name.ToUpper.EndsWith(res.aType.FExportName)) and (RttiType.TypeKind = tkDynArray) then
+          begin
+            ResValue := Invoke(Address,Args,SysCalConv,RttiType.Handle,False,IsConstr);
+            if ResValue.GetArrayLength > 0 then
+              CopyArrayContents(res.dta, ResValue.GetReferenceToRawData, 1, res.aType)
+            else
+              res.dta := nil;
+            Break;
+          end;
+      end;
+      { TODO add and test: btInterface  }
+      else
+//          writeln(stderr, 'Result type not implemented!');
+        Exit;
+    end;  { case }
+  end; //assigned(res)
+
+  Result := True;
+end;

--- a/Source/uPSC_dateutils.pas
+++ b/Source/uPSC_dateutils.pas
@@ -27,7 +27,6 @@ begin
   s.AddDelphiFunction('function UnixToDateTime(U: Int64): TDateTime;');
 
   s.AddDelphiFunction('function DateToStr(D: TDateTime): string;');
-  s.AddDelphiFunction('function StrToDate(const S: string): TDateTime;');
   s.AddDelphiFunction('function FormatDateTime(const fmt: string; D: TDateTime): string;');
 end;
 

--- a/Source/uPSPreProcessor.pas
+++ b/Source/uPSPreProcessor.pas
@@ -4,7 +4,14 @@ unit uPSPreProcessor;
 
 interface
 uses
-  Classes, SysUtils, uPSCompiler, uPSUtils;
+  Classes, SysUtils,
+  {$IFDEF NEXTGEN}
+  System.ByteStrings,
+  {$ENDIF}
+  {$IF NOT DEFINED (NEXTGEN) AND NOT DEFINED (MACOS) AND  DEFINED (DELPHI_TOKYO_UP)}
+  AnsiStrings,
+  {$ENDIF}
+  uPSCompiler, uPSUtils;
 
 
 
@@ -632,14 +639,14 @@ begin
             if FDefineState.DoWrite then
             begin
               if pos(' ', s) <> 0 then raise EPSPreProcessor.CreateFmt(RPS_DefineTooManyParameters, [Parser.Row, Parser.Col]);
-              FCurrentDefines.Add(Uppercase(S));
+              FCurrentDefines.Add(String({$IF NOT DEFINED (NEXTGEN) AND NOT DEFINED (MACOS) AND  DEFINED (DELPHI_TOKYO_UP)}AnsiStrings.{$ENDIF}Uppercase(S)));
             end;
           end else if (Name = 'UNDEF') then
           begin
             if FDefineState.DoWrite then
             begin
               if pos(' ', s) <> 0 then raise EPSPreProcessor.CreateFmt(RPS_DefineTooManyParameters, [Parser.Row, Parser.Col]);
-              i := FCurrentDefines.IndexOf(Uppercase(s));
+              i := FCurrentDefines.IndexOf(String({$IF NOT DEFINED (NEXTGEN) AND NOT DEFINED (MACOS) AND  DEFINED (DELPHI_TOKYO_UP)}AnsiStrings.{$ENDIF}Uppercase(S)));
               if i <> -1 then
                 FCurrentDefines.Delete(i);
             end;
@@ -647,13 +654,13 @@ begin
           begin
             if pos(' ', s) <> 0 then raise EPSPreProcessor.CreateFmt(RPS_DefineTooManyParameters, [Parser.Row, Parser.Col]);
             //JeromeWelsh - nesting fix
-            ADoWrite := (FCurrentDefines.IndexOf(Uppercase(s)) >= 0) and FDefineState.DoWrite;
+            ADoWrite := (FCurrentDefines.IndexOf(String({$IF NOT DEFINED (NEXTGEN) AND NOT DEFINED (MACOS) AND  DEFINED (DELPHI_TOKYO_UP)}AnsiStrings.{$ENDIF}Uppercase(S))) >= 0) and FDefineState.DoWrite;
             FDefineState.Add.DoWrite := ADoWrite;
           end else if (Name = 'IFNDEF') then
           begin
             if pos(' ', s) <> 0 then raise EPSPreProcessor.CreateFmt(RPS_DefineTooManyParameters, [Parser.Row, Parser.Col]);
             //JeromeWelsh - nesting fix
-            ADoWrite := (FCurrentDefines.IndexOf(Uppercase(s)) < 0) and FDefineState.DoWrite;
+            ADoWrite := (FCurrentDefines.IndexOf(String({$IF NOT DEFINED (NEXTGEN) AND NOT DEFINED (MACOS) AND  DEFINED (DELPHI_TOKYO_UP)}AnsiStrings.{$ENDIF}Uppercase(s))) < 0) and FDefineState.DoWrite;
             FDefineState.Add.DoWrite := ADoWrite;
           end else if (Name = 'ENDIF') then
           begin

--- a/Source/uPSR_dateutils.pas
+++ b/Source/uPSR_dateutils.pas
@@ -3,7 +3,7 @@ unit uPSR_dateutils;
 {$I PascalScript.inc}
 interface
 uses
-  SysUtils, uPSRuntime;
+  SysUtils, uPSRuntime, DateUtils;
 
 
 
@@ -43,21 +43,28 @@ end;
 
 procedure RegisterDateTimeLibrary_R(S: TPSExec);
 begin
-  S.RegisterDelphiFunction(@EncodeDate, 'EncodeDate', cdRegister);
-  S.RegisterDelphiFunction(@EncodeTime, 'EncodeTime', cdRegister);
-  S.RegisterDelphiFunction(@TryEncodeDate, 'TryEncodeDate', cdRegister);
-  S.RegisterDelphiFunction(@TryEncodeTime, 'TryEncodeTime', cdRegister);
-  S.RegisterDelphiFunction(@DecodeDate, 'DecodeDate', cdRegister);
-  S.RegisterDelphiFunction(@DecodeTime, 'DecodeTime', cdRegister);
-  S.RegisterDelphiFunction(@DayOfWeek, 'DayOfWeek', cdRegister);
-  S.RegisterDelphiFunction(@Date, 'Date', cdRegister);
-  S.RegisterDelphiFunction(@Time, 'Time', cdRegister);
-  S.RegisterDelphiFunction(@Now, 'Now', cdRegister);
-  S.RegisterDelphiFunction(@DateTimeToUnix, 'DateTimeToUnix', cdRegister);
-  S.RegisterDelphiFunction(@UnixToDateTime, 'UnixToDateTime', cdRegister);
-  S.RegisterDelphiFunction(@DateToStr, 'DateToStr', cdRegister);
-  S.RegisterDelphiFunction(@FormatDateTime, 'FormatDateTime', cdRegister);
-  S.RegisterDelphiFunction(@StrToDate, 'StrToDate', cdRegister);
+  S.RegisterDelphiFunction(@EncodeDate, 'ENCODEDATE', cdRegister);
+  S.RegisterDelphiFunction(@EncodeTime, 'ENCODETIME', cdRegister);
+  S.RegisterDelphiFunction(@TryEncodeDate, 'TRYENCODEDATE', cdRegister);
+  S.RegisterDelphiFunction(@TryEncodeTime, 'TRYENCODETIME', cdRegister);
+  S.RegisterDelphiFunction(@DecodeDate, 'DECODEDATE', cdRegister);
+  S.RegisterDelphiFunction(@DecodeTime, 'DECODETIME', cdRegister);
+  S.RegisterDelphiFunction(@DayOfWeek, 'DAYOFWEEK', cdRegister);
+  S.RegisterDelphiFunction(@Date, 'DATE', cdRegister);
+  S.RegisterDelphiFunction(@Time, 'TIME', cdRegister);
+  S.RegisterDelphiFunction(@Now, 'NOW', cdRegister);
+  S.RegisterDelphiFunction(@DateTimeToUnix, 'DATETIMETOUNIX', cdRegister);
+  S.RegisterDelphiFunction(@UnixToDateTime, 'UNIXTODATETIME', cdRegister);
+  S.RegisterDelphiFunction(@IncYear, 'INCYEAR', cdRegister);
+  S.RegisterDelphiFunction(@IncMonth, 'INCMONTH', cdRegister);
+  S.RegisterDelphiFunction(@IncWeek, 'INCWEEK', cdRegister);
+  S.RegisterDelphiFunction(@IncDay, 'INCDAY', cdRegister);
+  S.RegisterDelphiFunction(@IncHour, 'INCHOUR', cdRegister);
+  S.RegisterDelphiFunction(@IncMinute, 'INCMINUTE', cdRegister);
+  S.RegisterDelphiFunction(@IncSecond, 'INCSECOND', cdRegister);
+  S.RegisterDelphiFunction(@IncMilliSecond, 'INCMILLISECOND', cdRegister);
+  S.RegisterDelphiFunction(@DateToStr, 'DATETOSTR', cdRegister);
+  S.RegisterDelphiFunction(@FormatDateTime, 'FORMATDATETIME', cdRegister);
 end;
 
 end.

--- a/Source/uPSUtils.pas
+++ b/Source/uPSUtils.pas
@@ -3,7 +3,11 @@ unit uPSUtils;
 
 interface
 uses
-  Classes, SysUtils {$IFDEF VER130}, Windows {$ENDIF};
+  Classes, SysUtils
+  {$IFDEF NEXTGEN}, System.ByteStrings{$ENDIF}
+  {$IFDEF VER130}, Windows {$ENDIF};
+
+{$ZEROBASEDSTRINGS OFF}
 
 const
 
@@ -28,6 +32,9 @@ type
   TPSBaseType = Byte;
 
   TPSVariableType = (ivtGlobal, ivtParam, ivtVariable);
+
+  InternalScriptException = class(Exception)
+  end;
 
 const
 
@@ -307,14 +314,14 @@ type
 {$ENDIF}
 
   tbtchar = {$IFDEF DELPHI4UP}AnsiChar{$ELSE}CHAR{$ENDIF};
-{$IFNDEF PS_NOWIDESTRING}
 
-  tbtwidestring = widestring;
   tbtunicodestring = {$IFDEF DELPHI2009UP}UnicodeString{$ELSE}widestring{$ENDIF};
 
-  tbtwidechar = widechar;
+  tbtwidestring = {$IFDEF NEXTGEN}tbtunicodestring{$ELSE}widestring{$ENDIF};
+
+  tbtwidechar = {$IFDEF NEXTGEN}char{$ELSE}widechar{$ENDIF};
+
   tbtNativeString = {$IFDEF DELPHI2009UP}tbtUnicodeString{$ELSE}tbtString{$ENDIF};
-{$ENDIF}
 {$IFDEF FPC}
   IPointer = PtrUInt;
 {$ELSE}
@@ -1149,20 +1156,20 @@ procedure TPSPascalParser.Next;
 var
   Err: TPSParserErrorKind;
   FLastUpToken: TbtString;
-  function CheckReserved(Const S: ShortString; var CurrTokenId: TPSPasToken): Boolean;
+  function CheckReserved(Const S: TbtString; var CurrTokenId: TPSPasToken): Boolean;
   var
     L, H, I: LongInt;
-    J: tbtChar;
-    SName: ShortString;
+    J: SmallInt;
+    SName: TbtString;
   begin
     L := 0;
-    J := S[0];
+    J := Length(S);
     H := KEYWORD_COUNT-1;
     while L <= H do
     begin
       I := (L + H) shr 1;
       SName := LookupTable[i].Name;
-      if J = SName[0] then
+      if J = Length(SName) then
       begin
         if S = SName then
         begin
@@ -1726,6 +1733,7 @@ begin
   fUnitName := FastUpperCase(Value);
 end;
 
+{$ZEROBASEDSTRINGS ON}
 
 end.
 


### PR DESCRIPTION
… Win 86&64, Mac x32, should work on NEXTGEN as well.

2) correction for NEXTGEN compiler support in progress - no any compilation error, but still huge problems due to ARC.
3) added parameter FinalCleaning (default - True) to TPSPascalCompiler.Compile - for cleaning of unused stuff - memory leakage removed. For debug run - set to False.
4) added return value to TPSExecuteEvent (for compilation break in case of unsuccessful import)
5) raising of Exception changed to InternalScriptException - for filtering exceptions by class, f.e. in EurekaLog, madExcept and other exception handlers.
6) removed StrToDate from uPSC_dateutils - duplication from uPSI_SysUtils
7) in uPSDebugger added 3 methods (more info from debugger)
8) Added IncMinute and similar methods import to uPSR_dateutils - before were only in uPSC_dateutils
9) in uPSRuntime added more informative messages in case of Array out ob bounds, and few more.
10) small fixes and changes here and there.

on next commit will be added example of PS in thread work, and fully-functional debugger.