### PR TITLE
Fix Delphi Linux StrToFloat build

### DIFF
--- a/Source/uPSUtils.pas
+++ b/Source/uPSUtils.pas
@@ -753,6 +753,12 @@ function StrToFloat(const s: TbtString): Extended;
 var
   i: longint;
 begin
+  {$IFDEF LINUX}
+  {$IFNDEF FPC}
+  Result := SysUtils.StrToFloat(string(s), TFormatSettings.Invariant);
+  Exit;
+  {$ENDIF}
+  {$ENDIF}
   Val(string(s), Result, i);
   if i <> 0 then raise Exception.Create(RPS_InvalidFloat);
 end;


### PR DESCRIPTION
## Summary

This fixes a Delphi Linux build failure in `uPSUtils.StrToFloat`.

On Delphi/Linux, the current implementation calls:

```pascal
Val(string(s), Result, i);
```

where `Result` is `Extended`. That fails to compile because Delphi Linux does not support `Extended` as a distinct floating-point target in this context.

The patch keeps the existing `Val` implementation for Windows and FPC, and uses `SysUtils.StrToFloat` with invariant format settings only for Delphi/Linux. That preserves PascalScript's dot-decimal parsing behavior without changing the existing non-Linux path.

## Verification

Verified in a downstream Delphi 12 project where the current upstream `uPSUtils.pas` failed during a Linux64 build with:

```text
error E2008: Incompatible types
Val(string(s), Result, i);
```

After this change, the same downstream `execute Linux64 Release` build completes successfully.