### PR TITLE
Fix operator precedence hole in IsCompatibleType

### DIFF
--- a/Source/uPSCompiler.pas
+++ b/Source/uPSCompiler.pas
@@ -3287,7 +3287,10 @@ begin
     ((p1.BaseType = btUnicodeString) and (p2.BaseType = btWideChar)) or
     ((p1.BaseType = btUnicodeString) and ((p2.BaseType = btString) or (p2.BaseType = btPchar) or (p2.BaseType = btUnicodeString))) or
     ((p1.BaseType = btUnicodeString) and (p2.BaseType = btWidestring)) or
-    (((p1.basetype = btPchar) or (p1.BaseType = btString)) and (p2.BaseType = btWideString)or (p2.BaseType = btUnicodeString)) or
+    (((p1.basetype = btPchar) or (p1.BaseType = btString)) and
+      // the second/third term used to dangle outside the p1 check, which
+      // made EVERY destination type compatible with UnicodeString sources
+      ((p2.BaseType = btWideString) or (p2.BaseType = btUnicodeString))) or
     (((p1.basetype = btPchar) or (p1.BaseType = btString)) and (p2.BaseType = btWidechar)) or
     (((p1.basetype = btPchar) or (p1.BaseType = btString)) and (p2.BaseType = btchar)) or
     {$ENDIF}


### PR DESCRIPTION
One line of the big compatibility expression was missing parentheses:

  (((p1.basetype = btPchar) or (p1.BaseType = btString)) and
    (p2.BaseType = btWideString) or (p2.BaseType = btUnicodeString)) or

'and' binds stronger than 'or', so the (p2 = btUnicodeString) term stood
alone: ANY destination type was considered assignment-compatible with a
UnicodeString source. Since script 'string' is btUnicodeString nowadays,
these all compiled without error and only failed at runtime (or
corrupted data):

  var i: Integer; s: string; ... i := s;
  var b: Boolean; s: string; ... b := s;
  var d: Double;  s: string; ... d := s;

With the added parentheses the term applies - as clearly intended - only
to btPchar/btString destinations. String-to-string, WideString and Char
conversions keep compiling as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)