### PR TITLE
Report which LoadData stage failed instead of failing silently

### DIFF
--- a/Source/uPSRuntime.pas
+++ b/Source/uPSRuntime.pas
@@ -3063,16 +3063,22 @@ begin
   if not LoadTypes then
   begin
     Clear;
+    if ExEx = erNoError then
+      CMD_Err2(erCustomError, TbtString('Failed to load types'));
     exit;
   end;
   if not LoadProcs then
   begin
     Clear;
+    if ExEx = erNoError then
+      CMD_Err2(erCustomError, TbtString('Failed to load procedures'));
     exit;
   end;
   if not LoadVars then
   begin
     Clear;
+    if ExEx = erNoError then
+      CMD_Err2(erCustomError, TbtString('Failed to load variables'));
     exit;
   end;
   if (HDR.MainProcNo >= FProcs.Count) and (HDR.MainProcNo <> InvalidVal)then begin


### PR DESCRIPTION
Several failure paths inside LoadTypes/LoadProcs/LoadVars only return
False without calling CMD_Err. LoadData then cleared the instance and
returned False with ExceptionCode still erNoError, so hosts printing
TIFErrorToString(ExceptionCode, ExceptionString) showed 'No Error' for
a failed load.

Each stage now reports a stage-specific erCustomError - but only when
no more specific error is pending (ExEx = erNoError), so existing
detailed errors like 'Out Of Range' or 'Unexpected End Of File' are
preserved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)