### PR TITLE
Raise instead of silently dropping a property with an unresolved type

### DIFF
--- a/Source/uPSCompiler.pas
+++ b/Source/uPSCompiler.pas
@@ -15678,7 +15678,10 @@ begin
     if FType = nil then
     begin
       p.Free;
-      Exit;
+      // dropping the property silently leads to hard-to-diagnose 'Unknown
+      // identifier' errors in scripts; report the unresolved type instead
+      raise EPSCompilerException.CreateFmt(RPS_UnableToRegisterType,
+        [PropertyName + ': ' + PropertyType]);
     end;
     if p.Decl.Result = nil  then p.Decl.Result := FType else
     begin


### PR DESCRIPTION
TPSCompileTimeClass.RegisterProperty freed the half-built property and
returned silently when its type string referenced a type that was not
(yet) registered. Scripts using the property then failed with a bare
'Unknown identifier' - very hard to trace back to a wrong registration
order in an import unit. This is the actual root cause behind reports
like issue #255 ('Delphi 11 case sensitive').

Raise EPSCompilerException naming the property and its type string
instead, matching how AddTypeS and the other registration APIs report
bad input. Inside OnUses the exception surfaces as a regular compiler
error message.

Fixes #255 (the reported "case sensitivity" is actually this silent registration failure: the property is dropped and the script then fails with Unknown identifier).

🤖 Generated with [Claude Code](https://claude.com/claude-code)