### PR TITLE
Add a 'raise' statement and the ParamCount/ParamStr builtins

### DIFF
--- a/Source/uPSCompiler.pas
+++ b/Source/uPSCompiler.pas
@@ -10971,6 +10971,107 @@ begin
     Result := True;
   end; {ProcessIdentifier}
 
+  function ProcessRaise: Boolean;
+  { 'raise;' re-raises the current exception (compiled as a call to
+    RaiseLastException); 'raise <class>.Create(<message>);' compiles to
+    RaiseException(erCustomError, <message>). The class name is parsed but
+    not evaluated - scripts have no exception objects; the strict grammar
+    keeps the parser deterministic. }
+  var
+    L: Cardinal;
+    Decl: TPSParametersDecl;
+    Call: TPSValueProcNo;
+    Msg: TPSValue;
+    ExData: TPSValueData;
+    Con: TPSConstant;
+  begin
+    Result := False;
+    Debug_WriteLine(BlockInfo);
+    FParser.Next; // skip RAISE
+    if (FParser.CurrTokenId = CSTI_Semicolon) or (FParser.CurrTokenId = CSTII_End) or
+       (FParser.CurrTokenId = CSTII_Else) or (FParser.CurrTokenId = CSTII_Except) or
+       (FParser.CurrTokenId = CSTII_Finally) or (FParser.CurrTokenId = CSTII_until) then
+    begin // bare 'raise': re-raise the current exception
+      L := FindProc('RaiseLastException');
+      if L = InvalidVal then
+      begin
+        MakeError('', ecUnknownIdentifier, 'RaiseLastException');
+        exit;
+      end;
+      Call := TPSValueProcNo.Create;
+      Call.SetParserPos(FParser);
+      Call.ProcNo := L;
+      Call.ResultType := nil;
+      Call.Parameters := TPSParameters.Create;
+      Result := _ProcessFunction(Call, nil);
+      Call.Free;
+      exit;
+    end;
+    if FParser.CurrTokenId <> CSTI_Identifier then
+    begin
+      MakeError('', ecIdentifierExpected, '');
+      exit;
+    end;
+    FParser.Next;
+    if FParser.CurrTokenId <> CSTI_Period then
+    begin
+      MakeError('', ecPeriodExpected, '');
+      exit;
+    end;
+    FParser.Next;
+    if (FParser.CurrTokenId <> CSTI_Identifier) or (FParser.GetToken <> 'CREATE') then
+    begin
+      MakeError('', ecIdentifierExpected, FParser.OriginalToken);
+      exit;
+    end;
+    FParser.Next;
+    if FParser.CurrTokenId <> CSTI_OpenRound then
+    begin
+      MakeError('', ecOpenRoundExpected, '');
+      exit;
+    end;
+    FParser.Next;
+    L := FindProc('RaiseException');
+    Con := GetConstant('erCustomError');
+    if (L = InvalidVal) or (Con = nil) then
+    begin
+      MakeError('', ecUnknownIdentifier, 'RaiseException');
+      exit;
+    end;
+    Msg := Calc(CSTI_CloseRound);
+    if Msg = nil then
+      exit;
+    if FParser.CurrTokenId <> CSTI_CloseRound then
+    begin
+      MakeError('', ecCloseRoundExpected, '');
+      Msg.Free;
+      exit;
+    end;
+    FParser.Next;
+    if TPSProcedure(FProcs[L]).ClassType = TPSInternalProcedure then
+      Decl := TPSInternalProcedure(FProcs[L]).Decl
+    else
+      Decl := TPSExternalProcedure(FProcs[L]).RegProc.Decl;
+    ExData := TPSValueData.Create;
+    ExData.SetParserPos(FParser);
+    ExData.Data := NewVariant(at2ut(Con.Value.FType));
+    ExData.Data.tu32 := Con.Value.tu32;
+    Call := TPSValueProcNo.Create;
+    Call.SetParserPos(FParser);
+    Call.ProcNo := L;
+    Call.ResultType := Decl.Result;
+    Call.Parameters := TPSParameters.Create;
+    Call.Parameters.Add.Val := ExData;
+    Call.Parameters.Add.Val := Msg;
+    if not ValidateParameters(BlockInfo, Call.Parameters, Decl) then
+    begin
+      Call.Free;
+      exit;
+    end;
+    Result := _ProcessFunction(Call, nil);
+    Call.Free;
+  end; {ProcessRaise}
+
   function ProcessCase: Boolean;
   var
     V1, V2, TempRec, Val, CalcItem: TPSValue;
@@ -11675,6 +11776,12 @@ begin
                 BlockWriteLong(BlockInfo, $12345678);
                 FContinueOffsets.Add(Pointer(Length(BlockInfo.Proc.Data)));
                 FParser.Next;
+                if (BlockInfo.SubType = tifOneliner) or (BlockInfo.SubType = TOneLiner) then
+                  break;
+              end else if FParser.GetToken = 'RAISE' then
+              begin
+                if not ProcessRaise then
+                  exit;
                 if (BlockInfo.SubType = tifOneliner) or (BlockInfo.SubType = TOneLiner) then
                   break;
               end else
@@ -13952,6 +14059,8 @@ begin
   AddFunction('function ExceptionProc: Cardinal;');
   AddFunction('function ExceptionPos: Cardinal;');
   AddFunction('function ExceptionToString(er: TIFException; Param: string): string;');
+  AddFunction('function ParamCount: Integer;');
+  AddFunction('function ParamStr(Index: Integer): string;');
   {$IFNDEF PS_NOINT64}
   AddFunction('function StrToInt64(S: string): Int64;');
   AddFunction('function Int64ToStr(I: Int64): string;');

--- a/Source/uPSRuntime.pas
+++ b/Source/uPSRuntime.pas
@@ -9756,6 +9756,8 @@ begin
     47: Stack.SetUInt64(-1, StrToUInt64Def(string(Stack.GetAnsiString(-2)), Stack.GetUInt64(-3))); // StrToUInt64Def
 {$ENDIF}
     48: Stack.SetAnsiString(-1, tbtstring(SysUtils.UIntToStr({$IFNDEF PS_NOINT64}Stack.GetUInt64(-2){$ELSE}Stack.GetUInt(-2){$ENDIF}))); // UIntToStr
+    49: Stack.SetInt(-1, ParamCount); // ParamCount
+    50: {$IFNDEF PS_NOWIDESTRING}Stack.SetUnicodeString(-1, tbtunicodestring(ParamStr(Stack.GetInt(-2)))){$ELSE}Stack.SetAnsiString(-1, tbtstring(ParamStr(Stack.GetInt(-2)))){$ENDIF}; // ParamStr
     42:  // sizeof
       begin
         temp := NewTPSVariantIFC(Stack[Stack.Count -2], False);
@@ -10129,6 +10131,8 @@ begin
 
   RegisterFunctionName('IntToStr', DefProc, Pointer(0), nil);
   RegisterFunctionName('UIntToStr', DefProc, Pointer(48), nil);
+  RegisterFunctionName('ParamCount', DefProc, Pointer(49), nil);
+  RegisterFunctionName('ParamStr', DefProc, Pointer(50), nil);
   RegisterFunctionName('StrToInt', DefProc, Pointer(1), nil);
   RegisterFunctionName('StrToIntDef', DefProc, Pointer(2), nil);
   RegisterFunctionName('Pos', DefProc, Pointer(3), nil);


### PR DESCRIPTION
raise: scripts could report custom errors only through the
RaiseException builtin and could not re-raise inside except blocks with
the usual Pascal syntax. The identifier RAISE is now handled as a
statement in ProcessSub:

  raise;                              // re-raise: RaiseLastException
  raise Exception.Create('message');  // RaiseException(erCustomError, msg)

The class name is parsed but not evaluated (scripts have no exception
objects), the message may be any string expression, and the strict
<ident>.Create(<expr>) grammar keeps the single-token-lookahead parser
deterministic. Both forms work as if/then one-liners and interact with
try/except/finally as expected; ExceptionType/ExceptionParam report
erCustomError and the message.

ParamCount/ParamStr: the host process' command line was not reachable
from scripts. Registered as DefProc indices 49/50 (45-48 are taken by
the StrToUInt64 family and UIntToStr), kept in sync in
DefineStandardProcedures, DefProc and RegisterStandardProcs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)