### PR TITLE
Accept Delphi's 'packed' keyword in type declarations (fixes #246)

### DIFF
--- a/Source/uPSCompiler.pas
+++ b/Source/uPSCompiler.pas
@@ -4053,6 +4053,19 @@ var
   Intf: TPSInterface;
 {$ENDIF}
 begin
+  { issue #246: accept Delphi's 'packed' before structured type declarations.
+    PascalScript records/arrays are always packed, so it only affects parsing }
+  if (FParser.CurrTokenID = CSTI_Identifier) and (FParser.GetToken = 'PACKED') then
+  begin
+    FParser.Next;
+    if not ((FParser.CurrTokenId = CSTII_Record) or (FParser.CurrTokenId = CSTII_Array) or
+      (FParser.CurrTokenId = CSTII_Set)) then
+    begin
+      MakeError('', ecIdentifierExpected, '');
+      Result := nil;
+      Exit;
+    end;
+  end;
   if (FParser.CurrTokenID = CSTII_Function) or (FParser.CurrTokenID = CSTII_Procedure) then
   begin
      Result := ReadTypeAddProcedure(Name, FParser);


### PR DESCRIPTION
The parser rejected 'packed record', 'packed array' and 'packed set' in
script type sections and AddTypeS declarations, although PascalScript
records and arrays are always packed anyway - Delphi type declarations
could not be pasted into scripts unchanged.

ReadType now skips a leading 'packed' when a structured type
(record/array/set) follows; anything else after 'packed' is still an
error, and the memory layout is unaffected.

Repro (fails on master, passes with this change, DCC32+DCC64):
  type TP = packed record x, y: Integer; end;   // script type section
  Sender.AddTypeS('THostPacked', 'packed record a: Byte; b: Integer; end');

Fixes #246.

🤖 Generated with [Claude Code](https://claude.com/claude-code)