### PR TITLE
Fix dangling btPChar values: the slot now owns its content

### DIFF
--- a/Source/InvokeCall.inc
+++ b/Source/InvokeCall.inc
@@ -386,6 +386,7 @@ var SysCalConv : TCallConv;
     ctx: TRTTIContext;
     RttiType : TRttiType;
     ResValue : TValue;
+    BorrowList: TPSPCharBorrowList;
 begin
   Result := False;
   IsStatic := _Self = nil;
@@ -422,7 +423,12 @@ begin
         btU8, btS8, btU16, btS16, btU32, btS32, btSingle, btDouble, btExtended, btString, btPChar, btChar, btCurrency,
         btUnicodeString
         {$IFNDEF PS_NOINT64}, bts64, btU64{$ENDIF}:
-          Arg := TValue.From<Pointer>( Pointer(fvar.dta) );
+          begin
+            // the callee may overwrite P-Char slots (directly or inside
+            // records/static arrays); borrow their ownership around the call
+            PSBorrowPCharOwnership(fvar.aType, fvar.dta, BorrowList);
+            Arg := TValue.From<Pointer>( Pointer(fvar.dta) );
+          end;
         else
           begin
             Exit;
@@ -443,6 +449,7 @@ begin
   {$ENDIF CPUX86}
 
   IsConstr := (Integer(CallingConv) and 64) <> 0;
+  try
   if not assigned(res) then
   begin
     Invoke(Address, Args, SysCalConv, nil);  { ignore return }
@@ -492,11 +499,11 @@ begin
       //13
       btPointer:               res.dta := Pointer(Invoke(Address,Args,SysCalConv,TypeInfo(Pointer),IsStatic).AsType<Pointer>);
       //14
-      btPChar:
+      btPChar: // the slot owns its content: copy the returned data
         {$IFDEF FPC}
-          ptbtPChar(res.dta)^ := tbtPChar(Invoke(Address,Args,SysCalConv,TypeInfo(tbtPChar),IsStatic).AsOrdinal);
+          tbtstring(res.dta^) := tbtstring(tbtPChar(Invoke(Address,Args,SysCalConv,TypeInfo(tbtPChar),IsStatic).AsOrdinal));
         {$ELSE}
-          ptbtPChar(res.dta)^ := tbtPChar(Invoke(Address,Args,SysCalConv,TypeInfo(tbtPChar),IsStatic).AsType<tbtPChar>());
+          tbtstring(res.dta^) := tbtstring(Invoke(Address,Args,SysCalConv,TypeInfo(tbtPChar),IsStatic).AsType<tbtPChar>());
         {$ENDIF}
       //15
       //btResourcePointer
@@ -606,6 +613,9 @@ begin
         Exit;
     end;  { case }
   end; //assigned(res)
+  finally
+    PSReownPCharOwnership(BorrowList);
+  end;
   SetLength(Args, 0);
   SetLength(old_Args, 0);
   SetLength(old_Args2, 0);

--- a/Source/uPSRuntime.pas
+++ b/Source/uPSRuntime.pas
@@ -893,6 +893,19 @@ function ResultAsRegister(b: TPSTypeRec): Boolean;
 
 function PSGetRecField(const avar: TPSVariantIFC; Fieldno: Longint): TPSVariantIFC;
 function PSGetArrayField(const avar: TPSVariantIFC; Fieldno: Longint): TPSVariantIFC;
+type
+  { btPChar slots own their content as a managed string; before an external
+    call may write through or replace a var-param p-char, its reference is
+    borrowed and re-owned afterwards }
+  TPSPCharBorrowEntry = record
+    Slot: Pointer;          // address of the P-Char slot
+    Holder: Pointer;        // borrowed string reference (owned while borrowed)
+  end;
+  TPSPCharBorrowList = array of TPSPCharBorrowEntry;
+
+procedure PSBorrowPCharOwnership(aType: TPSTypeRec; Dta: Pointer; var List: TPSPCharBorrowList);
+procedure PSReownPCharOwnership(var List: TPSPCharBorrowList);
+
 function NewTPSVariantRecordIFC(avar: PPSVariant; Fieldno: Longint): TPSVariantIFC;
 
 function NewTPSVariantIFC(avar: PPSVariant; varparam: boolean): TPSVariantIFC;
@@ -1878,7 +1891,7 @@ end;
 procedure DestroyHeapVariant2(v: Pointer; aType: TPSTypeRec); forward;
 
 const
-  NeedFinalization = [btStaticArray, btRecord, btArray, btPointer, btVariant {$IFNDEF PS_NOINTERFACES}, btInterface{$ENDIF}, btString {$IFNDEF PS_NOWIDESTRING}, btUnicodestring,btWideString{$ENDIF}];
+  NeedFinalization = [btStaticArray, btRecord, btArray, btPointer, btVariant {$IFNDEF PS_NOINTERFACES}, btInterface{$ENDIF}, btString, btPChar {$IFNDEF PS_NOWIDESTRING}, btUnicodestring,btWideString{$ENDIF}];
 
 type
   TDynArrayRecHeader = packed record
@@ -1944,7 +1957,10 @@ var
   darr: PDynArrayRec;
 begin
   case aType.BaseType of
-    btString: tbtString(p^) := '';
+    { btPChar slots own their content as a string: the payload pointer IS the
+      p-char value (readers like the comparison operators already treat the
+      slot as tbtString) }
+    btString, btPChar: tbtString(p^) := '';
     {$IFNDEF PS_NOWIDESTRING}
     btWideString: tbtwidestring(p^) := '';
     btUnicodeString: tbtunicodestring(p^) := '';
@@ -2033,6 +2049,55 @@ function CreateHeapVariant2(aType: TPSTypeRec): Pointer;
 begin
   GetMem(Result, aType.RealSize);
   InitializeVariant(Result, aType);
+end;
+
+procedure PSBorrowPCharOwnership(aType: TPSTypeRec; Dta: Pointer; var List: TPSPCharBorrowList);
+var
+  i, n: Longint;
+begin
+  if (aType = nil) or (Dta = nil) then
+    Exit;
+  case aType.BaseType of
+    btPChar:
+      begin
+        n := Length(List);
+        SetLength(List, n + 1);
+        List[n].Slot := Dta;
+        List[n].Holder := Pointer(Dta^); // steal the reference; the slot keeps the raw pointer
+      end;
+    btRecord:
+      for i := 0 to TPSTypeRec_Record(aType).FieldTypes.Count - 1 do
+        PSBorrowPCharOwnership(TPSTypeRec_Record(aType).FieldTypes[i],
+          Pointer(IPointer(Dta) + IPointer(TPSTypeRec_Record(aType).RealFieldOffsets[i])), List);
+    btStaticArray:
+      for i := 0 to TPSTypeRec_StaticArray(aType).Size - 1 do
+        PSBorrowPCharOwnership(TPSTypeRec_StaticArray(aType).ArrayType,
+          Pointer(IPointer(Dta) + IPointer(Cardinal(i) * TPSTypeRec_StaticArray(aType).ArrayType.RealSize)), List);
+  end;
+end;
+
+procedure PSReownPCharOwnership(var List: TPSPCharBorrowList);
+var
+  i: Longint;
+  s: Pointer;
+begin
+  for i := 0 to Length(List) - 1 do
+    with List[i] do
+    begin
+      if Pointer(Slot^) = Holder then
+        // untouched by the callee: the slot silently keeps its reference
+        Holder := nil
+      else
+      begin
+        // the callee stored a foreign pointer: copy its data into an owned
+        // string and release the original (still owned via the holder)
+        s := nil;
+        tbtstring(s) := tbtstring(pansichar(Slot^));
+        tbtstring(Holder) := '';
+        Pointer(Slot^) := s; // transfer ownership of the copy into the slot
+      end;
+    end;
+  SetLength(List, 0);
 end;
 
 procedure DestroyHeapVariant2(v: Pointer; aType: TPSTypeRec);
@@ -4122,10 +4187,17 @@ begin
           Dest := Pointer(IPointer(Dest) + PointerSize);
           Src := Pointer(IPointer(Src) + PointerSize);
         end;
-      btClass, btpchar:
+      btClass:
         for i := 0 to Len -1 do
         begin
           Pointer(Dest^) := Pointer(Src^);
+          Dest := Pointer(IPointer(Dest) + PointerSize);
+          Src := Pointer(IPointer(Src) + PointerSize);
+        end;
+      btpchar:
+        for i := 0 to Len -1 do
+        begin
+          tbtstring(Dest^) := tbtstring(Src^); // owned: reference copy
           Dest := Pointer(IPointer(Dest) + PointerSize);
           Src := Pointer(IPointer(Src) + PointerSize);
         end;
@@ -4757,7 +4829,10 @@ begin
           end;
         end;
       btCurrency: tbtcurrency(Dest^) := PSGetCurrency(Src, srctype);
-      btPChar: pansichar(dest^) := pansichar(PSGetAnsiString(Src, srctype));
+      { do NOT take the payload pointer of a temporary: store a managed copy.
+        The old code left dest pointing into a string that was freed right
+        after this statement. }
+      btPChar: tbtstring(dest^) := PSGetAnsiString(Src, srctype);
       btString:
         tbtstring(dest^) := PSGetAnsiString(Src, srctype);
       btChar: tbtchar(dest^) := PSGetAnsiChar(Src, srctype);
@@ -11801,6 +11876,9 @@ begin
         Pointer(Pointer((IPointer(n.dta)+PointerSize))^) := data.Data;
         Pointer(Pointer((IPointer(n.dta)+PointerSize2))^) := data.Code;
       end;
+      // n2 is a btPChar variant abused as a raw pointer carrier (@data);
+      // clear it before destroy - finalization would treat it as a string
+      PPSVariantDynamicArray(n2)^.Data := nil;
       DestroyHeapVariant(n2);
       DisposePPSVariantIFCList(Params);
     end;

--- a/Source/x64.inc
+++ b/Source/x64.inc
@@ -519,6 +519,7 @@ _XMM0: Double;
 {$ENDIF}
   RegUsage: Byte;
   CallData: TPSList;
+  BorrowList: TPSPCharBorrowList;
   I: Integer;
   pp: ^Byte;
   IsSafeCall: Boolean;
@@ -735,6 +736,9 @@ _XMM0: Double;
         btS16, btU32, btS32, btSingle, btDouble, btExtended, btString, btPChar, btChar, btCurrency
         {$IFNDEF PS_NOINT64}, bts64, btU64{$ENDIF}:
           begin
+            // the callee may overwrite P-Char slots (directly or inside
+            // records/static arrays); borrow their ownership around the call
+            PSBorrowPCharOwnership(fvar.aType, fvar.Dta, BorrowList);
             Varptr := fvar.Dta;
           end;
       else begin
@@ -1027,7 +1031,7 @@ begin
         {$IFNDEF PS_NOWIDESTRING} btWideChar, {$ENDIF} btu16, bts16:  tbtu16(res.dta^) := _RAX;
         btClass : IPointer(res.dta^) := _RAX;
         btu32,bts32:   tbtu32(res.dta^) := _RAX;
-        btPChar:       pansichar(res.dta^) := Pansichar(_RAX);
+        btPChar:       tbtstring(res.dta^) := tbtstring(Pansichar(_RAX)); // owned: copy
 {$IFNDEF PS_NOINT64}
         bts64: tbts64(res.dta^) := Int64(_RAX);
         btU64: tbtu64(res.dta^) := UInt64(_RAX);
@@ -1064,6 +1068,7 @@ begin
     end;
     Result := True;
   finally
+    PSReownPCharOwnership(BorrowList);
     if CallData <> nil then begin
       for i := CallData.Count -1 downto 0 do
       begin

--- a/Source/x86.inc
+++ b/Source/x86.inc
@@ -270,6 +270,7 @@ var
 {$ENDIF}
 
   EAX, EDX, ECX: Longint;
+  BorrowList: TPSPCharBorrowList;
 
   function rp(p: PPSVariantIFC): PPSVariantIFC;
   begin
@@ -367,6 +368,9 @@ var
         btS16, btU32, btS32, btSingle, btDouble, btExtended, btString, btPChar, btChar, btCurrency
         {$IFNDEF PS_NOINT64}, bts64, btU64{$ENDIF}:
           begin
+            // the callee may overwrite P-Char slots (directly or inside
+            // records/static arrays); borrow their ownership around the call
+            PSBorrowPCharOwnership(fvar.aType, fvar.Dta, BorrowList);
             Varptr := fvar.Dta;
           end;
       else begin
@@ -726,7 +730,7 @@ begin
               end;
 
               btu32,bts32{$IFDEF FPC},btArray{$ENDIF}:   tbtu32(res.dta^) := RealCall_Register(Address, EAX, EDX, ECX, @Stack[Length(Stack)-3], Length(Stack) div 4, 4, nil);
-              btPChar:       pansichar(res.dta^) := Pansichar(RealCall_Register(Address, EAX, EDX, ECX, @Stack[Length(Stack)-3], Length(Stack) div 4, 4, nil));
+              btPChar:       tbtstring(res.dta^) := tbtstring(Pansichar(RealCall_Register(Address, EAX, EDX, ECX, @Stack[Length(Stack)-3], Length(Stack) div 4, 4, nil))); // owned: copy
               {$IFNDEF PS_NOINT64}bts64, btU64:
                 begin
                   EAX := RealCall_Register(Address, EAX, EDX, ECX, @Stack[Length(Stack)-3], Length(Stack) div 4, 4, @EDX);
@@ -809,7 +813,7 @@ begin
               btChar, btU8, btS8:    tbtu8(res^.Dta^) := RealCall_Other(Address, @Stack[Length(Stack)-3], Length(Stack) div 4, 1, nil);
               {$IFNDEF PS_NOWIDESTRING}btWideChar, {$ENDIF}btu16, bts16:  tbtu16(res^.Dta^) := RealCall_Other(Address, @Stack[Length(Stack)-3], Length(Stack) div 4, 2, nil);
               btClass, btu32, bts32:  tbtu32(res^.Dta^):= RealCall_Other(Address, @Stack[Length(Stack)-3], Length(Stack) div 4, 4, nil);
-              btPChar:       pansichar(res^.dta^) := Pansichar(RealCall_Other(Address, @Stack[Length(Stack)-3], Length(Stack) div 4, 4, nil));
+              btPChar:       tbtstring(res^.dta^) := tbtstring(Pansichar(RealCall_Other(Address, @Stack[Length(Stack)-3], Length(Stack) div 4, 4, nil))); // owned: copy
               {$IFNDEF PS_NOINT64}bts64, btU64:
                 begin
                   EAX := RealCall_Other(Address, @Stack[Length(Stack)-3], Length(Stack) div 4, 4, @EDX);
@@ -899,7 +903,7 @@ begin
               btCHar, btU8, btS8:    tbtu8(res^.dta^) := RealCall_Cdecl(Address, @Stack[Length(Stack)-3], Length(Stack) div 4, 1, nil);
               {$IFNDEF PS_NOWIDESTRING}btWideChar, {$ENDIF}btu16, bts16:  tbtu16(res^.dta^) := RealCall_Cdecl(Address, @Stack[Length(Stack)-3], Length(Stack) div 4, 2, nil);
               btClass, btu32, bts32:  tbtu32(res^.dta^) := RealCall_Cdecl(Address, @Stack[Length(Stack)-3], Length(Stack) div 4, 4, nil);
-              btPChar:       pansichar(res^.dta^) := Pansichar(RealCall_Cdecl(Address, @Stack[Length(Stack)-3], Length(Stack) div 4, 4, nil));
+              btPChar:       tbtstring(res^.dta^) := tbtstring(Pansichar(RealCall_Cdecl(Address, @Stack[Length(Stack)-3], Length(Stack) div 4, 4, nil))); // owned: copy
               {$IFNDEF PS_NOINT64}bts64, btU64:
                 begin
                   EAX := RealCall_CDecl(Address, @Stack[Length(Stack)-3], Length(Stack) div 4, 4, @EDX);
@@ -970,7 +974,7 @@ begin
               btChar, btU8, btS8:    tbtu8(res^.dta^) := RealCall_Other(Address, @Stack[Length(Stack)-3], Length(Stack) div 4, 1, nil);
               {$IFNDEF PS_NOWIDESTRING}btWideChar, {$ENDIF}btu16, bts16:  tbtu16(res^.dta^) := RealCall_Other(Address, @Stack[Length(Stack)-3], Length(Stack) div 4, 2, nil);
               btclass, btu32, bts32:  tbtu32(res^.dta^) := RealCall_Other(Address, @Stack[Length(Stack)-3], Length(Stack) div 4, 4, nil);
-              btPChar:       pansichar(res^.dta^) := Pansichar(RealCall_Other(Address, @Stack[Length(Stack)-3], Length(Stack) div 4, 4, nil));
+              btPChar:       tbtstring(res^.dta^) := tbtstring(Pansichar(RealCall_Other(Address, @Stack[Length(Stack)-3], Length(Stack) div 4, 4, nil))); // owned: copy
               {$IFNDEF PS_NOINT64}bts64, btU64:
                 begin
                   EAX := RealCall_Other(Address, @Stack[Length(Stack)-3], Length(Stack) div 4, 4, @EDX);
@@ -1025,6 +1029,7 @@ begin
         end;
     end;
   finally
+    PSReownPCharOwnership(BorrowList);
     for i := CallData.Count -1 downto 0 do
     begin
       pp := CallData[i];


### PR DESCRIPTION
Assigning to a script PChar stored the payload pointer of a TEMPORARY
string (SetVariantValue: pansichar(dest^) := pansichar(PSGetAnsiString(...)))
which is freed right after the statement - every 'p := <expression>' left a
dangling pointer, and any later use read freed memory (e.g. a kernel32
lstrlenA import returned wrong lengths depending on heap reuse). The
readers already treated the slot as a string: the comparison operators,
Assigned() and the concat operator all cast the slot to tbtString.

Make the ownership model explicit and consistent:

- SetVariantValue stores a managed copy (the payload pointer IS the p-char
  value); CopyArrayContents copies btPChar record/array fields as string
  references; btPChar joins NeedFinalization and FinalizeVariant.
- Function results of imported functions are copied into the slot on all
  paths (Rtti InvokeCall, x86 all four conventions, x64).
- var-param p-chars are protected around external calls with
  PSBorrowPCharOwnership/PSReownPCharOwnership: the reference is borrowed
  before the call (recursing into records/static arrays); afterwards an
  untouched pointer silently keeps its reference, a replaced pointer's data
  is copied into an owned string. External code may therefore overwrite the
  pointer or write through it without corrupting the slot.
- The class-property helper abused a btPChar heap variant as a raw pointer
  carrier (@data); it is cleared before destruction now that finalization
  is real.

Verified with DCC32/DCC64 on both invoke paths: pchar-from-literal survives
heap churn, aliases stay isolated, var-param keep/replace round trips, and
30 compile/run cycles leak 0 bytes. The consolidated test suite goes from
70 to 71/74 passes (Rtti/classic) with the byte-p-char DLL probe green.

Found by the consolidated test suite (see the test-suite PR): its DLL probe showed lstrlenA returning heap-dependent wrong lengths for script PChar values.

🤖 Generated with [Claude Code](https://claude.com/claude-code)