### PR TITLE
uPSDebugger: add HasCodeAtRow for exact breakpoint-line testing

### DIFF
--- a/Source/uPSDebugger.pas
+++ b/Source/uPSDebugger.pas
@@ -38,6 +38,12 @@ type
     function TranslatePosition(Proc, Position: Cardinal): Cardinal;
     
     function TranslatePositionEx(Proc, Position: Cardinal; var Pos, Row, Col: Cardinal; var Fn: tbtstring): Boolean;
+
+    { True when any opcode of any procedure maps to source row Row. This is
+      the exact "may a breakpoint sit on this line" test for IDEs - only
+      meaningful while DebugDataLoaded is True. Fn filters by source/module
+      name ('' = any file). }
+    function HasCodeAtRow(Row: Cardinal; const Fn: tbtstring = ''): Boolean;
     
     procedure LoadDebugData(const Data: tbtstring);
 	
@@ -271,6 +277,32 @@ begin
   c^.FParamNames := TIfStringList.Create;
   FProcs.Add(c);
   REsult := c;
+end;
+
+function TPSCustomDebugExec.HasCodeAtRow(Row: Cardinal; const Fn: tbtstring): Boolean;
+var
+  i, j: Longint;
+  fi: PFunctionInfo;
+  r: PPositionData;
+begin
+  Result := False;
+  if FDebugDataForProcs = nil then
+    Exit;
+  for i := 0 to FDebugDataForProcs.Count - 1 do
+  begin
+    fi := FDebugDataForProcs[i];
+    if fi^.FPositionTable = nil then
+      Continue;
+    for j := 0 to fi^.FPositionTable.Count - 1 do
+    begin
+      r := PPositionData(fi^.FPositionTable[j]);
+      if (r^.Row = Row) and ((Fn = '') or (r^.FileName = Fn)) then
+      begin
+        Result := True;
+        Exit;
+      end;
+    end;
+  end;
 end;
 
 procedure TPSCustomDebugExec.LoadDebugData(const Data: tbtstring);


### PR DESCRIPTION
Adds `TPSCustomDebugExec.HasCodeAtRow(Row, Fn)` - a public, read-only query
answering "can a breakpoint sit on this source line?" by scanning the debug
position tables that are already built during `LoadDebugData`.

### Why

An IDE/editor integrating the debugger has to decide, per source line, whether
to offer a breakpoint (gutter glyph, F5 toggle). The information is exact in
the position table - every opcode records its source row - but there was no
public accessor: callers had to walk the private `FDebugDataForProcs` tables
themselves, or fall back to a text heuristic that cannot distinguish a
declaration body, a comment or a continuation line from real executable code.

### What

```pascal
{ True when any opcode of any procedure maps to source row Row.
  Fn filters by module name ('' = any file). }
function HasCodeAtRow(Row: Cardinal; const Fn: tbtstring = ''): Boolean;
```

A small scan of the loaded tables; returns False when no debug data is loaded.
No new state, no behavior change to existing methods.

### Verified

DCC32/DCC64: against a compiled script the table correctly reports executable
lines True and declaration / `begin` / blank lines False (exactly what a gutter
needs). Trivial portable Pascal - no Exit(value)/generics.

🤖 Generated with [Claude Code](https://claude.com/claude-code)